### PR TITLE
Added support for inline codegen in SerdeDiff derive

### DIFF
--- a/examples/nested_struct.rs
+++ b/examples/nested_struct.rs
@@ -13,10 +13,16 @@ struct MySimpleStruct {
     val: u32,
 }
 
+// Example of a struct that does not implement SerdeDiff, but is still usable with `#[serde_diff(inline)]`
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+struct InlineTest(i32);
+
 // This struct is contained within MyStruct for a more complex example case
 #[derive(SerdeDiff, Clone, Serialize, Deserialize, Debug)]
 struct MyInnerStruct {
     x: f32,
+    #[serde_diff(inline)]
+    inline: InlineTest,
     a_string: String,
     string_list: Vec<String>,
     string_list2: Vec<String>,
@@ -41,6 +47,7 @@ fn main() {
         s: "A string".to_string(),
         c: MyInnerStruct {
             x: 40.0,
+            inline: InlineTest(9),
             a_string: "my string".to_string(),
             string_list: vec!["str1".to_string(), "str3".to_string()],
             string_list2: vec!["str6".to_string(), "str7".to_string()],
@@ -56,6 +63,7 @@ fn main() {
         s: "A string".to_string(),
         c: MyInnerStruct {
             x: 39.0,
+            inline: InlineTest(4),
             a_string: "my other string".to_string(),
             string_list: vec!["str1".to_string(), "str2".to_string(), "str3".to_string()],
             string_list2: vec!["str6".to_string()],
@@ -76,11 +84,12 @@ fn main() {
     // Create a struct to which we will apply a diff. This is a mix of old and new state from
     // the diff
     let target = MyStruct {
-        a: 5.0, // old, 5.0 -> 3.0
-        b: 31, // old, 31 -> 32
+        a: 5.0,                    // old, 5.0 -> 3.0
+        b: 31,                     // old, 31 -> 32
         s: "A string".to_string(), // unchanged
         c: MyInnerStruct {
-            x: 40.0, // old, 40.0 -> 39.0
+            x: 40.0,                                                    // old, 40.0 -> 39.0
+            inline: InlineTest(9),                                      // old, 9 -> 4
             a_string: "my string".to_string(), // old, "my string" -> "my other string"
             string_list: vec!["str1".to_string(), "str5".to_string()], // does not match old or new, "str2" was added
             string_list2: vec!["str6".to_string(), "str7".to_string()], // old, "str7" was removed

--- a/serde-diff-derive/src/serde_diff/args.rs
+++ b/serde-diff-derive/src/serde_diff/args.rs
@@ -1,4 +1,4 @@
-use darling::{FromField, FromDeriveInput};
+use darling::{FromDeriveInput, FromField};
 
 /// Metadata from the struct's type annotation
 #[derive(Debug, FromDeriveInput)]
@@ -21,21 +21,30 @@ pub struct SerdeDiffFieldArgs {
     /// If true, this field should be ignored
     #[darling(default)]
     skip: bool,
+
+    /// If true, simple diff should be generated inline
+    #[darling(default)]
+    inline: bool,
 }
 
 impl SerdeDiffFieldArgs {
     /// Name of the field
     pub fn ident(&self) -> &Option<syn::Ident> {
-        return &self.ident
+        return &self.ident;
     }
 
     /// Type of the field
     pub fn ty(&self) -> &syn::Type {
-       return &self.ty
-   }
+        return &self.ty;
+    }
+
+    /// If true, simple diff should be generated inline
+    pub fn skip(&self) -> bool {
+        return self.skip;
+    }
 
     /// If true, this field should be ignored
-    pub fn skip(&self) -> bool {
-        return self.skip
+    pub fn inline(&self) -> bool {
+        return self.inline;
     }
 }


### PR DESCRIPTION
`#[serde_diff(inline)]` can be added to any field in a struct to support types that do not implement SerdeDiff but do implement `PartialEq+Serialize+Deserialize`.