### PR TITLE
Make it build on wasm32-unknown-unknown by excluding OsString

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,6 +726,7 @@ simple_serde_diff!(f64);
 simple_serde_diff!(char);
 simple_serde_diff!(String);
 simple_serde_diff!(std::ffi::CString);
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 simple_serde_diff!(std::ffi::OsString);
 simple_serde_diff!(std::num::NonZeroU8);
 simple_serde_diff!(std::num::NonZeroU16);


### PR DESCRIPTION
It wasn't building on wasm32, due to OsString:
```
error: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:689: the trait bound `std::ffi::OsString: _IMPL_SERIALIZE_FOR_DiffCommandRef::_serde::Serialize` is not satisfied
error: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:689: the trait `_IMPL_SERIALIZE_FOR_DiffCommandRef::_serde::Serialize` is not implemented for `std::ffi::OsString`
help: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:729: in this macro invocation
error: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:704: the trait bound `for<'c> std::ffi::OsString: _IMPL_SERIALIZE_FOR_DiffCommandRef::_serde::Deserialize<'c>` is not satisfied
error: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:704: the trait `for<'c> _IMPL_SERIALIZE_FOR_DiffCommandRef::_serde::Deserialize<'c>` is not implemented for `std::ffi::OsString`
help: C:\Users\me\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-diff-0.1.3\src\lib.rs:729: in this macro invocation
error: could not compile `serde-diff`.
```
https://github.com/amethyst/serde-diff/blob/master/src/lib.rs#L729

By excluding OsString, now it builds on wasm32 :)