### PR TITLE
Support for arrays and Option

### DIFF
--- a/serde-diff-derive/src/serde_diff/args.rs
+++ b/serde-diff-derive/src/serde_diff/args.rs
@@ -30,21 +30,21 @@ pub struct SerdeDiffFieldArgs {
 impl SerdeDiffFieldArgs {
     /// Name of the field
     pub fn ident(&self) -> &Option<syn::Ident> {
-        return &self.ident;
+        &self.ident
     }
 
     /// Type of the field
     pub fn ty(&self) -> &syn::Type {
-        return &self.ty;
+        &self.ty
     }
 
     /// If true, simple diff should be generated inline
     pub fn skip(&self) -> bool {
-        return self.skip;
+        self.skip
     }
 
     /// If true, this field should be ignored
     pub fn inline(&self) -> bool {
-        return self.inline;
+        self.inline
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate as serde_diff;
 #[doc(hidden)]
 pub use serde as _serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ macro_rules! tuple_impls {
                 ) -> Result<bool, S::Error> {
                     let mut changed = false;
                     $(
-                        ctx.push_field(stringify!($name));
+                        ctx.push_field(stringify!($n));
                         changed |= <$name as serde_diff::SerdeDiff>::diff(&self.$n, ctx, &other.$n)?;
                         ctx.pop_path_element()?;
                     )+
@@ -782,7 +782,7 @@ macro_rules! tuple_impls {
                     while let Some(serde_diff::DiffPathElementValue::Field(element)) = ctx.next_path_element(seq)? {
                         match element.as_ref() {
                             $(
-                                stringify!($name) => changed |= <$name as serde_diff::SerdeDiff>::apply(&mut self.$n, seq, ctx)?,
+                                stringify!($n) => changed |= <$name as serde_diff::SerdeDiff>::apply(&mut self.$n, seq, ctx)?,
                             )+
                             _ => ctx.skip_value(seq)?,
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,7 @@ impl<T: SerdeDiff + Serialize + for<'a> Deserialize<'a>> SerdeDiff for Vec<T> {
     }
 }
 
-macro_rules! serde_diff_array {
+macro_rules! array_impls {
     ($($len:tt)+) => {
         $(
             impl<T: $crate::SerdeDiff + serde::Serialize + for<'a> serde::Deserialize<'a>> $crate::SerdeDiff for [T; $len] {
@@ -740,13 +740,77 @@ macro_rules! serde_diff_array {
     }
 }
 
-serde_diff_array! {
+array_impls! {
     01 02 03 04 05 06 07 08 09 10
     11 12 13 14 15 16 17 18 19 20
     21 22 23 24 25 26 27 28 29 30
     31 32
     40 48 50 56 64 72 96 100 128 160 192 200 224 256 384 512
     768 1024 2048 4096 8192 16384 32768 65536
+}
+
+macro_rules! tuple_impls {
+    ($($len:expr => ($($n:tt $name:ident)+))+) => {
+        $(
+            impl<$($name),+> $crate::SerdeDiff for ($($name,)+)
+            where
+                $($name: $crate::SerdeDiff + serde::Serialize + for<'a> serde::Deserialize<'a>,)+
+            {
+                fn diff<'a, S: serde::ser::SerializeSeq>(
+                    &self,
+                    ctx: &mut $crate::DiffContext<'a, S>,
+                    other: &Self,
+                ) -> Result<bool, S::Error> {
+                    let mut changed = false;
+                    $(
+                        ctx.push_field(stringify!($name));
+                        changed |= <$name as serde_diff::SerdeDiff>::diff(&self.$n, ctx, &other.$n)?;
+                        ctx.pop_path_element()?;
+                    )+
+                    Ok(changed)
+                }
+
+                fn apply<'de, A>(
+                    &mut self,
+                    seq: &mut A,
+                    ctx: &mut $crate::ApplyContext,
+                ) -> Result<bool, <A as serde::de::SeqAccess<'de>>::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut changed = false;
+                    while let Some(serde_diff::DiffPathElementValue::Field(element)) = ctx.next_path_element(seq)? {
+                        match element.as_ref() {
+                            $(
+                                stringify!($name) => changed |= <$name as serde_diff::SerdeDiff>::apply(&mut self.$n, seq, ctx)?,
+                            )+
+                            _ => ctx.skip_value(seq)?,
+                        }
+                    }
+                    Ok(changed)
+                }
+            }
+        )+
+    }
+}
+
+tuple_impls! {
+    1 => (0 T0)
+    2 => (0 T0 1 T1)
+    3 => (0 T0 1 T1 2 T2)
+    4 => (0 T0 1 T1 2 T2 3 T3)
+    5 => (0 T0 1 T1 2 T2 3 T3 4 T4)
+    6 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5)
+    7 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6)
+    8 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7)
+    9 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8)
+    10 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9)
+    11 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10)
+    12 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11)
+    13 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12)
+    14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13)
+    15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14)
+    16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15)
 }
 
 /// Implements SerdeDiff on a type given that it impls Serialize + Deserialize + PartialEq.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+use std::fmt::Debug;
+
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+struct TestStruct {
+    a: u32,
+    b: f64,
+}
+
+fn roundtrip<T: SerdeDiff + Serialize + for<'a> Deserialize<'a> + PartialEq + Debug + Clone>(
+    old: T,
+    new: T,
+) {
+    let diff = Diff::serializable(&old, &new);
+    let json_diff = serde_json::to_string(&diff).unwrap();
+    let mut deserializer = serde_json::Deserializer::from_str(&json_diff);
+    let mut target = old.clone();
+    Apply::apply(&mut deserializer, &mut target).unwrap();
+    assert_eq!(target, new);
+
+    let bincode_diff = bincode::serialize(&diff).unwrap();
+    let mut target = old;
+    bincode::config()
+        .deserialize_seed(Apply::deserializable(&mut target), &bincode_diff)
+        .unwrap();
+    assert_eq!(target, new);
+}
+
+fn partial<T: SerdeDiff + Serialize + for<'a> Deserialize<'a> + PartialEq + Debug + Clone>(
+    old: T,
+    new: T,
+    target: T,
+    expected: T,
+) {
+    let diff = Diff::serializable(&old, &new);
+    let json_diff = serde_json::to_string(&diff).unwrap();
+    let mut deserializer = serde_json::Deserializer::from_str(&json_diff);
+    let mut tmp_target = target.clone();
+    Apply::apply(&mut deserializer, &mut tmp_target).unwrap();
+    assert_eq!(tmp_target, expected);
+
+    let bincode_diff = bincode::serialize(&diff).unwrap();
+    let mut tmp_target = target;
+    bincode::config()
+        .deserialize_seed(Apply::deserializable(&mut tmp_target), &bincode_diff)
+        .unwrap();
+    assert_eq!(tmp_target, expected);
+}
+
+#[test]
+fn test_option() {
+    roundtrip(None::<TestStruct>, None);
+    roundtrip(None, Some(TestStruct { a: 42, b: 12. }));
+    roundtrip(Some(TestStruct { a: 42, b: 12. }), None);
+    roundtrip(
+        Some(TestStruct { a: 52, b: 32. }),
+        Some(TestStruct { a: 42, b: 12. }),
+    );
+
+    partial(
+        Some(TestStruct { a: 5, b: 2. }),
+        Some(TestStruct { a: 8, b: 2. }),
+        Some(TestStruct { a: 0, b: 4. }),
+        Some(TestStruct { a: 8, b: 4. }),
+    );
+}
+
+#[test]
+fn test_array() {
+    partial([0, 1, 2, 3], [0, 1, 9, 3], [4, 5, 6, 7], [4, 5, 9, 7]);
+
+    partial(
+        Some([0, 1, 2, 3]),
+        Some([0, 1, 9, 3]),
+        Some([4, 5, 6, 7]),
+        Some([4, 5, 9, 7]),
+    );
+
+    partial(
+        [
+            None,
+            Some(TestStruct { a: 5, b: 2. }),
+            Some(TestStruct { a: 5, b: 2. }),
+        ],
+        [
+            Some(TestStruct { a: 8, b: 2. }),
+            Some(TestStruct { a: 8, b: 2. }),
+            None,
+        ],
+        [None, Some(TestStruct { a: 0, b: 4. }), None],
+        [
+            Some(TestStruct { a: 8, b: 2. }),
+            Some(TestStruct { a: 8, b: 4. }),
+            None,
+        ],
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,3 +95,39 @@ fn test_array() {
         ],
     );
 }
+
+#[test]
+fn test_tuple() {
+    roundtrip(
+        (None::<TestStruct>, Some(TestStruct { a: 8, b: 2. })),
+        (None, Some(TestStruct { a: 8, b: 2. })),
+    );
+
+    partial((0, 1, 2, 3), (0, 1, 9, 3), (4, 5, 6, 7), (4, 5, 9, 7));
+
+    partial(
+        Some((0, 1, 2, 3)),
+        Some((0, 1, 9, 3)),
+        Some((4, 5, 6, 7)),
+        Some((4, 5, 9, 7)),
+    );
+
+    partial(
+        (
+            None,
+            Some(TestStruct { a: 5, b: 2. }),
+            Some(TestStruct { a: 5, b: 2. }),
+        ),
+        (
+            Some(TestStruct { a: 8, b: 2. }),
+            Some(TestStruct { a: 8, b: 2. }),
+            None,
+        ),
+        (None, Some(TestStruct { a: 0, b: 4. }), None),
+        (
+            Some(TestStruct { a: 8, b: 2. }),
+            Some(TestStruct { a: 8, b: 4. }),
+            None,
+        ),
+    );
+}


### PR DESCRIPTION
Added support for arrays (for the same sizes as `serde-big-array`) and `Option<T>`.

I'd really like to have [tuple support](https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs#L306), too.

Can we reuse the array code for tuples, even though they are heterogenous?
Or do we need to do the same as for structs?
It would also be desirable to `inline` and `skip` tuple members!

Also, it would be nice to have const-generics array support, like this:
https://github.com/est31/serde-big-array/blob/29b38f1deec66b07d1fc10b266169ba694e1de5f/src/const_generics.rs#L14