### PR TITLE
Add support for HashMap and BTreeMap

### DIFF
--- a/examples/map.rs
+++ b/examples/map.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+use serde_diff::{Apply, Diff, SerdeDiff};
+use std::collections::HashMap;
+
+#[derive(SerdeDiff, Serialize, Deserialize, Debug, Default, PartialEq)]
+struct TestStruct {
+    test: bool,
+    //#[serde_diff(inline)]
+    map: HashMap<String, Vec<String>>,
+}
+
+fn main() {
+    let mut empty = TestStruct::default();
+    empty.test = true;
+
+    let mut hello_world = TestStruct::default();
+    hello_world
+        .map
+        .insert("hello".to_string(), vec!["world".to_string()]);
+
+    let mut hi_world = TestStruct::default();
+    hi_world
+        .map
+        .insert("hi".to_string(), vec!["world".to_string()]);
+
+    let mut hi_world_and_planet = TestStruct::default();
+    hi_world_and_planet.map.insert(
+        "hi".to_string(),
+        vec!["world".to_string(), "planet".to_string()],
+    );
+
+    let mut hi_planet = TestStruct::default();
+    hi_planet
+        .map
+        .insert("hi".to_string(), vec!["planet".to_string()]);
+
+    let add_hello = serde_json::to_string(&Diff::serializable(&empty, &hello_world)).unwrap();
+    let hello_to_hi = serde_json::to_string(&Diff::serializable(&hello_world, &hi_world)).unwrap();
+    let add_planet =
+        serde_json::to_string(&Diff::serializable(&hi_world, &hi_world_and_planet)).unwrap();
+    let del_world =
+        serde_json::to_string(&Diff::serializable(&hi_world_and_planet, &hi_planet)).unwrap();
+
+    let mut built = TestStruct::default();
+    for (diff, after) in &[
+        (add_hello, hello_world),
+        (hello_to_hi, hi_world),
+        (add_planet, hi_world_and_planet),
+        (del_world, hi_planet),
+    ] {
+        println!("{}", diff);
+
+        let mut deserializer = serde_json::Deserializer::from_str(&diff);
+        Apply::apply(&mut deserializer, &mut built).unwrap();
+
+        assert_eq!(after, &built);
+    }
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use serde_diff::{Apply, Diff, SerdeDiff};
-use serde::{Serialize, Deserialize};
 #[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
 struct TestStruct {
     a: u32,
@@ -7,27 +7,16 @@ struct TestStruct {
 }
 
 fn main() {
-    let old = TestStruct {
-        a: 5,
-        b: 2.,
-    };
+    let old = TestStruct { a: 5, b: 2. };
     let new = TestStruct {
         a: 8, // Differs from old.a, will be serialized
         b: 2.,
     };
-    let mut target = TestStruct {
-        a: 0,
-        b: 4.,
-    };
+    let mut target = TestStruct { a: 0, b: 4. };
     let json_data = serde_json::to_string(&Diff::serializable(&old, &new)).unwrap();
     let mut deserializer = serde_json::Deserializer::from_str(&json_data);
     Apply::apply(&mut deserializer, &mut target).unwrap();
 
-
-    let result = TestStruct {
-        a: 8,
-        b: 4.,
-    };
+    let result = TestStruct { a: 8, b: 4. };
     assert_eq!(result, target);
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,10 +277,12 @@ impl ApplyContext {
         // this tries to skip the value without knowing the type - not possible for some formats..
         while let Some(cmd) = seq.next_element_seed(DiffCommandIgnoreValue {})? {
             match cmd {
-                DiffCommandValue::Enter(_) | DiffCommandValue::AddKey(_) | DiffCommandValue::EnterKey(_) => depth += 1,
+                DiffCommandValue::Enter(_)
+                | DiffCommandValue::AddKey(_)
+                | DiffCommandValue::EnterKey(_) => depth += 1,
                 DiffCommandValue::Exit => depth -= 1,
                 DiffCommandValue::Value(_) | DiffCommandValue::Remove(_) => depth -= 1, // ignore value, but reduce depth, as it is an implicit Exit
-                DiffCommandValue::RemoveKey(_) => {},
+                DiffCommandValue::RemoveKey(_) => {}
                 DiffCommandValue::Nothing | DiffCommandValue::DeserializedValue => {
                     panic!("should never serialize cmd Nothing or DeserializedValue")
                 }
@@ -366,7 +368,15 @@ enum DiffCommandField {
     Exit,
 }
 struct DiffCommandFieldVisitor;
-const VARIANTS: &'static [&'static str] = &["Enter", "Value", "Remove", "AddKey", "EnterKey", "RemoveKey", "Exit"];
+const VARIANTS: &'static [&'static str] = &[
+    "Enter",
+    "Value",
+    "Remove",
+    "AddKey",
+    "EnterKey",
+    "RemoveKey",
+    "Exit",
+];
 impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
     type Value = DiffCommandField;
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -467,7 +477,10 @@ where
                             de::VariantAccess::newtype_variant::<DiffPathElementValue>(variant)?;
                         Ok(DiffCommandValue::Enter(enter))
                     }
-                    (DiffCommandField::Value, variant) | (DiffCommandField::AddKey, variant) | (DiffCommandField::EnterKey, variant) | (DiffCommandField::RemoveKey, variant) => {
+                    (DiffCommandField::Value, variant)
+                    | (DiffCommandField::AddKey, variant)
+                    | (DiffCommandField::EnterKey, variant)
+                    | (DiffCommandField::RemoveKey, variant) => {
                         de::VariantAccess::newtype_variant_seed::<DeserWrapper<T>>(
                             variant, self.seed,
                         )?;
@@ -533,7 +546,10 @@ impl<'de> de::DeserializeSeed<'de> for DiffCommandIgnoreValue {
                             de::VariantAccess::newtype_variant::<DiffPathElementValue>(variant)?;
                         Ok(DiffCommandValue::Enter(enter))
                     }
-                    (DiffCommandField::Value, variant) | (DiffCommandField::AddKey, variant) | (DiffCommandField::EnterKey, variant) | (DiffCommandField::RemoveKey, variant) => {
+                    (DiffCommandField::Value, variant)
+                    | (DiffCommandField::AddKey, variant)
+                    | (DiffCommandField::EnterKey, variant)
+                    | (DiffCommandField::RemoveKey, variant) => {
                         de::VariantAccess::newtype_variant::<de::IgnoredAny>(variant)?;
                         Ok(DiffCommandValue::Value(()))
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,11 @@ use serde::{
     Deserialize, Serialize, Serializer,
 };
 pub use serde_diff_derive::SerdeDiff;
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    hash::Hash,
+};
 
 // NEXT STEPS:
 // - Decouple from serde_json as much as possible. We might need to use a "stream" format with
@@ -243,6 +247,10 @@ impl ApplyContext {
         use DiffCommandValue::*;
         let element = match seq.next_element_seed(DiffCommandIgnoreValue {})? {
             Some(Enter(element)) => Ok(Some(element)),
+            Some(AddKey(_)) | Some(EnterKey(_)) | Some(RemoveKey(_)) => {
+                //self.skip_value(seq);
+                Ok(None)
+            }
             Some(Value(_)) | Some(Remove(_)) => panic!("unexpected DiffCommand Value or Remove"),
             Some(Exit) | Some(Nothing) | Some(DeserializedValue) | None => Ok(None),
         };
@@ -269,9 +277,10 @@ impl ApplyContext {
         // this tries to skip the value without knowing the type - not possible for some formats..
         while let Some(cmd) = seq.next_element_seed(DiffCommandIgnoreValue {})? {
             match cmd {
-                DiffCommandValue::Enter(_) => depth += 1,
+                DiffCommandValue::Enter(_) | DiffCommandValue::AddKey(_) | DiffCommandValue::EnterKey(_) => depth += 1,
                 DiffCommandValue::Exit => depth -= 1,
                 DiffCommandValue::Value(_) | DiffCommandValue::Remove(_) => depth -= 1, // ignore value, but reduce depth, as it is an implicit Exit
+                DiffCommandValue::RemoveKey(_) => {},
                 DiffCommandValue::Nothing | DiffCommandValue::DeserializedValue => {
                     panic!("should never serialize cmd Nothing or DeserializedValue")
                 }
@@ -325,6 +334,9 @@ impl ApplyContext {
             cmd @ Some(DiffCommandValue::Remove(_))
             | cmd @ Some(DiffCommandValue::Value(_))
             | cmd @ Some(DiffCommandValue::Enter(_))
+            | cmd @ Some(DiffCommandValue::AddKey(_))
+            | cmd @ Some(DiffCommandValue::EnterKey(_))
+            | cmd @ Some(DiffCommandValue::RemoveKey(_))
             | cmd @ Some(DiffCommandValue::Exit) => cmd,
             _ => None,
         })
@@ -348,10 +360,13 @@ enum DiffCommandField {
     Enter,
     Value,
     Remove,
+    AddKey,
+    EnterKey,
+    RemoveKey,
     Exit,
 }
 struct DiffCommandFieldVisitor;
-const VARIANTS: &'static [&'static str] = &["Enter", "Value", "Remove", "Exit"];
+const VARIANTS: &'static [&'static str] = &["Enter", "Value", "Remove", "AddKey", "EnterKey", "RemoveKey", "Exit"];
 impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
     type Value = DiffCommandField;
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -365,10 +380,13 @@ impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
             0u64 => Ok(DiffCommandField::Enter),
             1u64 => Ok(DiffCommandField::Value),
             2u64 => Ok(DiffCommandField::Remove),
-            3u64 => Ok(DiffCommandField::Exit),
+            3u64 => Ok(DiffCommandField::AddKey),
+            4u64 => Ok(DiffCommandField::EnterKey),
+            5u64 => Ok(DiffCommandField::RemoveKey),
+            6u64 => Ok(DiffCommandField::Exit),
             _ => Err(de::Error::invalid_value(
                 de::Unexpected::Unsigned(value),
-                &"variant index 0 <= i < 4",
+                &"variant index 0 <= i < 7",
             )),
         }
     }
@@ -380,6 +398,9 @@ impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
             "Enter" => Ok(DiffCommandField::Enter),
             "Value" => Ok(DiffCommandField::Value),
             "Remove" => Ok(DiffCommandField::Remove),
+            "AddKey" => Ok(DiffCommandField::AddKey),
+            "EnterKey" => Ok(DiffCommandField::EnterKey),
+            "RemoveKey" => Ok(DiffCommandField::RemoveKey),
             "Exit" => Ok(DiffCommandField::Exit),
             _ => Err(de::Error::unknown_variant(value, VARIANTS)),
         }
@@ -392,6 +413,9 @@ impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
             b"Enter" => Ok(DiffCommandField::Enter),
             b"Value" => Ok(DiffCommandField::Value),
             b"Remove" => Ok(DiffCommandField::Remove),
+            b"AddKey" => Ok(DiffCommandField::AddKey),
+            b"EnterKey" => Ok(DiffCommandField::EnterKey),
+            b"RemoveKey" => Ok(DiffCommandField::RemoveKey),
             b"Exit" => Ok(DiffCommandField::Exit),
             _ => {
                 let value = &serde::export::from_utf8_lossy(value);
@@ -443,7 +467,7 @@ where
                             de::VariantAccess::newtype_variant::<DiffPathElementValue>(variant)?;
                         Ok(DiffCommandValue::Enter(enter))
                     }
-                    (DiffCommandField::Value, variant) => {
+                    (DiffCommandField::Value, variant) | (DiffCommandField::AddKey, variant) | (DiffCommandField::EnterKey, variant) | (DiffCommandField::RemoveKey, variant) => {
                         de::VariantAccess::newtype_variant_seed::<DeserWrapper<T>>(
                             variant, self.seed,
                         )?;
@@ -509,7 +533,7 @@ impl<'de> de::DeserializeSeed<'de> for DiffCommandIgnoreValue {
                             de::VariantAccess::newtype_variant::<DiffPathElementValue>(variant)?;
                         Ok(DiffCommandValue::Enter(enter))
                     }
-                    (DiffCommandField::Value, variant) => {
+                    (DiffCommandField::Value, variant) | (DiffCommandField::AddKey, variant) | (DiffCommandField::EnterKey, variant) | (DiffCommandField::RemoveKey, variant) => {
                         de::VariantAccess::newtype_variant::<de::IgnoredAny>(variant)?;
                         Ok(DiffCommandValue::Value(()))
                     }
@@ -545,6 +569,14 @@ pub enum DiffCommandRef<'a, T: Serialize> {
     Value(&'a T),
     /// Remove N items from end of collection
     Remove(usize),
+    /// Add a key to a map
+    AddKey(&'a T),
+    /// Enter a key in a map.
+    /// This isn't part of Enter because then DiffPathElementValue would have to be generic over T
+    // Fortunately, keys on HashMaps are terminal as far as we're concerned.
+    EnterKey(&'a T),
+    /// Remove a key from a map
+    RemoveKey(&'a T),
     /// Exit a path element
     Exit,
 }
@@ -558,6 +590,12 @@ pub enum DiffCommandValue<'a, T> {
     Value(T),
     /// Remove N items from end of collection
     Remove(usize),
+    /// Add a key to a map
+    AddKey(T),
+    // Enter a key in a map
+    EnterKey(T),
+    /// Remove a key from a map
+    RemoveKey(T),
     // Exit a path element
     Exit,
     // Never serialized
@@ -673,6 +711,85 @@ impl<T: SerdeDiff + Serialize + for<'a> Deserialize<'a>> SerdeDiff for Vec<T> {
         Ok(changed)
     }
 }
+
+impl<K, V> SerdeDiff for HashMap<K, V>
+where
+    K: SerdeDiff + Serialize + for<'a> Deserialize<'a> + Hash + Eq,
+    V: SerdeDiff + Serialize + for<'a> Deserialize<'a>,
+{
+    fn diff<'a, S: SerializeSeq>(
+        &self,
+        ctx: &mut DiffContext<'a, S>,
+        other: &Self,
+    ) -> Result<bool, S::Error> {
+        let mut changed = false;
+
+        // TODO: detect renames
+        for (key, self_value) in self.iter() {
+            match other.get(key) {
+                Some(other_value) => {
+                    ctx.save_command(&DiffCommandRef::EnterKey(key), true)?;
+                    if <V as SerdeDiff>::diff(self_value, ctx, other_value)? {
+                        changed = true;
+                    }
+                },
+                None => {
+                    ctx.save_command(&DiffCommandRef::RemoveKey(key), true)?;
+                    changed = true;
+                },
+            }
+        }
+
+        for (key, other_value) in other.iter() {
+            if !self.contains_key(key) {
+                ctx.save_command(&DiffCommandRef::AddKey(key), true)?;
+                ctx.save_command(&DiffCommandRef::Value(other_value), true)?;
+                changed = true;
+            }
+        }
+
+        ctx.save_command::<()>(&DiffCommandRef::Exit, true)?;
+        Ok(changed)
+    }
+
+    fn apply<'de, A>(
+        &mut self,
+        seq: &mut A,
+        ctx: &mut ApplyContext,
+    ) -> Result<bool, <A as de::SeqAccess<'de>>::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut changed = false;
+        while let Some(cmd) = ctx.read_next_command::<A, K>(seq)? {
+            use DiffCommandValue::*;
+            use DiffPathElementValue::*;
+            match cmd {
+                // we should not be getting fields when reading collection commands
+                Enter(Field(_)) => {
+                    ctx.skip_value(seq)?;
+                    break;
+                }
+                AddKey(key) => if let Some(Value(v)) = ctx.read_next_command(seq)? {
+                    //changed |= self.insert(key, v).map(|old_val| v != old_val).unwrap_or(true);
+                    self.insert(key, v);
+                    changed = true;
+                } else {
+                    panic!("Expected value after AddKey");
+                }
+                EnterKey(key) => if let Some(value_ref) = self.get_mut(&key) {
+                    changed |= <V as SerdeDiff>::apply(value_ref, seq, ctx)?;
+                } else {
+                    ctx.skip_value(seq)?;
+                }
+                RemoveKey(key) => changed |= self.remove(&key).is_some(),
+                _ => break,
+            }
+        }
+        Ok(changed)
+    }
+}
+
 /// Implements SerdeDiff on a type given that it impls Serialize + Deserialize + PartialEq.
 /// This makes the type a "terminal" type in the SerdeDiff hierarchy, meaning deeper inspection
 /// will not be possible. Use the SerdeDiff derive macro for recursive field inspection.


### PR DESCRIPTION
This adds support for both `HashMap<K, V>` and `BTreeMap<K, V>`. See the new `map` example.

I'm also running `cargo fmt` across the entire codebase. If you don't want to include that, I think there's a way to accept the first two commits without that one. If not, I'll force-push it away upon request.

This does change the diff format (and the public API in turn), so the minor(?) version should be incremented if/when this is released.