### PR TITLE
Add rust-messagepack to example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ serde_derive = { version = "1", features = ["deserialize_in_place"]}
 [dev-dependencies]
 serde_json = "1.0"
 bincode = "1.2"
+rmp-serde = "0.14.1"

--- a/examples/nested_struct.rs
+++ b/examples/nested_struct.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Serialize into a couple different formats
     let json_data = serde_json::to_string(&diff)?;
     let bincode_data = bincode::serialize(&diff)?;
+    let msgpack_data = rmp_serde::to_vec_named(&diff)?;
 
     println!("{}", &json_data);
     // Create a struct to which we will apply a diff. This is a mix of old and new state from
@@ -116,9 +117,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!(
-        "bincode size {} json size {}",
+        "bincode size {} json size {} msgpack size {}",
         bincode_data.len(),
-        json_data.len()
+        json_data.len(),
+        msgpack_data.len(),
     );
     Ok(())
 }


### PR DESCRIPTION
This could be interesting to some audience since it shows that at least
in this case, [rust-messagepack](https://github.com/3Hren/msgpack-rust) seems to be the smallest representation
out of the box.

For comparison, I gzip compressed the bincode variant and reduced size
to 349 bytes, down from 419 bytes, which makes the 206 bytes of
messagepack even more attractive. It's nearly one-third of the the
size of JSON, coming in at 587 bytes.

Please feel free to close this PR, too, as I never asked if this kind of contribution is useful to this project. It's just me contributing everything I come up with if it could even remotely be interesting to others.