### PR TITLE
Add Support for Enumerated Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # serde-diff
 
 A small helper that can
-1. Serialize the fields that differ between two structs of the same type 
-2. Apply previously serialized field differences to other structs.
+1. Serialize the fields that differ between two values of the same type 
+2. Apply previously serialized field differences to other values of the same type.
 
-The SerdeDiff trait impl can serialize field paths recursively, greatly reducing the amount of data that needs to be serialized when only a small part of a struct has changed. 
+The SerdeDiff trait impl can serialize field paths recursively, greatly reducing the amount of data that needs to be serialized when only a small part of a struct/enum has changed. 
 
 [![Build Status][build_img]][build_lnk] [![Crates.io][crates_img]][crates_lnk] [![Docs.rs][doc_img]][doc_lnk]
 
@@ -16,7 +16,7 @@ The SerdeDiff trait impl can serialize field paths recursively, greatly reducing
 [doc_lnk]: https://docs.rs/serde-diff
 
 ## Usage
-On a struct:
+On a struct or enum:
 ```rust
 #[derive(SerdeDiff, Serialize, Deserialize)]
 ```
@@ -123,6 +123,27 @@ Skip fields:
 struct WrapperStruct {
     #[serde_diff(skip)]
     value: ExternalType,
+}
+```
+
+Generics:
+```rust
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+struct GenericStruct<T>
+where
+    T: SerdeDiff,
+{
+    a: T,
+}
+```
+
+Enums:
+```rust
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+enum TestEnum {
+    Structish { x: u32, y: u32 },
+    Enumish(i32, i32, i32),
+    Unitish,
 }
 ```
 

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -3,8 +3,8 @@ use serde_diff::{Apply, Diff, SerdeDiff};
 
 #[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
 enum TestEnum {
-    Structish {x : u32, y: u32}, 
-    Enumish (i32, i32, i32),
+    Structish { x: u32, y: u32 },
+    Enumish(i32, i32, i32),
     Unitish,
 }
 
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
         let mut target = TestEnum::Structish { x: 0, y: 4 };
         Apply::apply(&mut deserializer, &mut target)?;
-        
+
         let result = TestEnum::Structish { x: 8, y: 4 };
         assert_eq!(result, target);
     }
@@ -31,22 +31,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
-        let mut target = TestEnum::Enumish ( 1, 2, 3);        
+        let mut target = TestEnum::Enumish(1, 2, 3);
         Apply::apply(&mut deserializer, &mut target)?;
-        /* we can't apply changes from one enum variant 
+        /* we can't apply changes from one enum variant
         to another, as there may be unfilled fields with no sane defaults,
         should there be an error? probably.*/
-        let result = TestEnum::Enumish ( 1, 2, 3);
+        let result = TestEnum::Enumish(1, 2, 3);
         assert_eq!(result, target);
     }
     {
-        let old = TestEnum::Enumish (1, 2, 3);
-        let new = TestEnum::Enumish (1, 10, 3);
+        let old = TestEnum::Enumish(1, 2, 3);
+        let new = TestEnum::Enumish(1, 10, 3);
         let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
-        let mut target = TestEnum::Enumish ( 4, 3, 2);        
+        let mut target = TestEnum::Enumish(4, 3, 2);
         Apply::apply(&mut deserializer, &mut target)?;
-        let result = TestEnum::Enumish (4, 10, 2); 
+        let result = TestEnum::Enumish(4, 10, 2);
         assert_eq!(result, target);
     }
     {
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let new = TestEnum::Unitish;
         let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
-        let mut target = TestEnum::Enumish ( 1, 2, 3);        
+        let mut target = TestEnum::Enumish(1, 2, 3);
         Apply::apply(&mut deserializer, &mut target)?;
         let result = TestEnum::Unitish;
         assert_eq!(result, target);

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use serde_diff::{Apply, Diff, SerdeDiff};
+
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+enum TestEnum {
+    Structish {x : u32, y: u32}, 
+    Enumish (i32, i32, i32),
+    Unitish,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    {
+        let old = TestEnum::Structish { x: 5, y: 2 };
+        let new = TestEnum::Structish {
+            x: 8, // Differs from old.a, will be serialized
+            y: 2,
+        };
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        let mut target = TestEnum::Structish { x: 0, y: 4 };
+        Apply::apply(&mut deserializer, &mut target)?;
+        
+        let result = TestEnum::Structish { x: 8, y: 4 };
+        assert_eq!(result, target);
+    }
+    {
+        let old = TestEnum::Structish { x: 5, y: 2 };
+        let new = TestEnum::Structish {
+            x: 8, // Differs from old.a, will be serialized
+            y: 2,
+        };
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        let mut target = TestEnum::Enumish ( 1, 2, 3);        
+        Apply::apply(&mut deserializer, &mut target)?;
+        /* we can't apply changes from one enum variant 
+        to another, as there may be unfilled fields with no sane defaults,
+        should there be an error? probably.*/
+        let result = TestEnum::Enumish ( 1, 2, 3);
+        assert_eq!(result, target);
+    }
+    {
+        let old = TestEnum::Enumish (1, 2, 3);
+        let new = TestEnum::Enumish (1, 10, 3);
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        let mut target = TestEnum::Enumish ( 4, 3, 2);        
+        Apply::apply(&mut deserializer, &mut target)?;
+        let result = TestEnum::Enumish (4, 10, 2); 
+        assert_eq!(result, target);
+    }
+    {
+        let old = TestEnum::Structish { x: 5, y: 2 };
+        let new = TestEnum::Unitish;
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        let mut target = TestEnum::Enumish ( 1, 2, 3);        
+        Apply::apply(&mut deserializer, &mut target)?;
+        let result = TestEnum::Unitish;
+        assert_eq!(result, target);
+    }
+    Ok(())
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -15,6 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let mut target = TestStruct { a: 0, b: 4. };
     let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+    println!("{}", json_data);
     let mut deserializer = serde_json::Deserializer::from_str(&json_data);
     Apply::apply(&mut deserializer, &mut target)?;
 

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -11,6 +11,13 @@ struct Test2Struct(u32, u32, u32);
 #[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
 struct Test3Struct;
 
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+struct Test4Struct<T>
+where T: SerdeDiff
+{
+    a: T,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let old = TestStruct { a: 5, b: 2. };
@@ -50,6 +57,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Apply::apply(&mut deserializer, &mut target)?;
 
         let result = Test3Struct;
+        assert_eq!(result, target);
+    }
+    {
+        let old = Test4Struct { a: 5};
+        let new = Test4Struct { a: 7};
+        let mut target = Test4Struct { a: 10};
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        Apply::apply(&mut deserializer, &mut target)?;
+
+        let result = Test4Struct { a: 7};
         assert_eq!(result, target);
     }
     Ok(())

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use serde_diff::{Apply, Diff, SerdeDiff};
+
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+struct TestStruct {
+    a: u32,
+    b: f64,
+}
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+struct Test2Struct(u32, u32, u32);
+#[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
+struct Test3Struct;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    {
+        let old = TestStruct { a: 5, b: 2. };
+        let new = TestStruct {
+            a: 8, // Differs from old.a, will be serialized
+            b: 2.,
+        };
+        let mut target = TestStruct { a: 0, b: 4. };
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        Apply::apply(&mut deserializer, &mut target)?;
+
+        let result = TestStruct { a: 8, b: 4. };
+        assert_eq!(result, target);
+    }
+    {
+        let old = Test2Struct (1, 2, 3);
+        let new = Test2Struct (
+            5, // Differs from old.0, will be serialized
+            2,
+            3
+        );
+        let mut target = Test2Struct (4,5,6);
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        Apply::apply(&mut deserializer, &mut target)?;
+
+        let result = Test2Struct ( 5,5,6 );
+        assert_eq!(result, target);
+    }
+    {
+        let old = Test3Struct;
+        let new = Test3Struct;
+        let mut target = Test3Struct;
+        let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
+        let mut deserializer = serde_json::Deserializer::from_str(&json_data);
+        Apply::apply(&mut deserializer, &mut target)?;
+
+        let result = Test3Struct;
+        assert_eq!(result, target);
+    }
+    Ok(())
+}

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -13,7 +13,8 @@ struct Test3Struct;
 
 #[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug)]
 struct Test4Struct<T>
-where T: SerdeDiff
+where
+    T: SerdeDiff,
 {
     a: T,
 }
@@ -34,18 +35,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(result, target);
     }
     {
-        let old = Test2Struct (1, 2, 3);
-        let new = Test2Struct (
+        let old = Test2Struct(1, 2, 3);
+        let new = Test2Struct(
             5, // Differs from old.0, will be serialized
-            2,
-            3
+            2, 3,
         );
-        let mut target = Test2Struct (4,5,6);
+        let mut target = Test2Struct(4, 5, 6);
         let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
         Apply::apply(&mut deserializer, &mut target)?;
 
-        let result = Test2Struct ( 5,5,6 );
+        let result = Test2Struct(5, 5, 6);
         assert_eq!(result, target);
     }
     {
@@ -60,14 +60,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(result, target);
     }
     {
-        let old = Test4Struct { a: 5};
-        let new = Test4Struct { a: 7};
-        let mut target = Test4Struct { a: 10};
+        let old = Test4Struct { a: 5 };
+        let new = Test4Struct { a: 7 };
+        let mut target = Test4Struct { a: 10 };
         let json_data = serde_json::to_string(&Diff::serializable(&old, &new))?;
         let mut deserializer = serde_json::Deserializer::from_str(&json_data);
         Apply::apply(&mut deserializer, &mut target)?;
 
-        let result = Test4Struct { a: 7};
+        let result = Test4Struct { a: 7 };
         assert_eq!(result, target);
     }
     Ok(())

--- a/serde-diff-derive/src/serde_diff/args.rs
+++ b/serde-diff-derive/src/serde_diff/args.rs
@@ -9,6 +9,8 @@ pub struct SerdeDiffStructArgs {
     /// Whether the struct is opaque or not
     #[darling(default)]
     pub opaque: bool,
+
+    pub generics: syn::Generics,
 }
 
 /// Metadata from the struct's field annotations

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -18,7 +18,7 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                  generate_opaque(&input, struct_args)
              } else {
                  // Go ahead and generate the code                 
-                 match generate_enum(&input, struct_args) {
+                 match generate(&input, struct_args) {
                      //Ok(v) => {eprintln!("{}", v); v},
                      Ok(v) => v,
                      Err(v) => v,
@@ -30,7 +30,7 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                  generate_opaque(&input, struct_args)
              } else {
                  // Go ahead and generate the code                 
-                 match generate_enum(&input, struct_args) {
+                 match generate(&input, struct_args) {
                      //Ok(v) => {eprintln!("{}", v); v},
                      Ok(v) => v,
                      Err(v) => v,
@@ -63,7 +63,7 @@ struct ParsedField {
     field_args: args::SerdeDiffFieldArgs,
 }
 
-fn generate_enum_fields_diff(
+fn generate_fields_diff(
     parsed_fields: &[ParsedField],
     matching : bool,
 ) -> proc_macro2::TokenStream {
@@ -183,7 +183,7 @@ fn generate_arms(name: &syn::Ident, variant: Option<&syn::Ident>, fields: &syn::
     let mut diff_match_arms = vec![];
     let mut apply_match_arms = vec![];
     let parsed_fields = ok_fields(&fields)?;
-    let diffs = generate_enum_fields_diff(
+    let diffs = generate_fields_diff(
         &parsed_fields,
         matching,
     );                    
@@ -292,7 +292,7 @@ fn generate_arms(name: &syn::Ident, variant: Option<&syn::Ident>, fields: &syn::
     Ok((diff_match_arms, apply_match_arms))
 }
 
-fn generate_enum(
+fn generate(
     input: &syn::DeriveInput,
     struct_args: args::SerdeDiffStructArgs,
 ) -> Result<proc_macro::TokenStream, proc_macro::TokenStream> {
@@ -379,8 +379,10 @@ fn generate_enum(
 
     // Generate the impl block with the diff and apply functions within it
     let struct_name = &struct_args.ident;
+    let generics = &struct_args.generics.params;
+    let where_clause =  &struct_args.generics.where_clause;
     let diff_impl = quote! {
-        impl serde_diff::SerdeDiff for #struct_name {
+        impl <#generics> serde_diff::SerdeDiff for #struct_name < #generics> #where_clause {
             #diff_fn
             #apply_fn
         }

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -19,7 +19,6 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
              } else {
                  // Go ahead and generate the code                 
                  match generate(&input, struct_args) {
-                     //Ok(v) => {eprintln!("{}", v); v},
                      Ok(v) => v,
                      Err(v) => v,
                  }
@@ -31,7 +30,6 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
              } else {
                  // Go ahead and generate the code                 
                  match generate(&input, struct_args) {
-                     //Ok(v) => {eprintln!("{}", v); v},
                      Ok(v) => v,
                      Err(v) => v,
                  }
@@ -270,7 +268,7 @@ fn generate_arms(name: &syn::Ident, variant: Option<&syn::Ident>, fields: &syn::
                     while let Some(element) = ctx.next_path_element(seq)? {
                         match element {
                             #(#apply_fn_field_handlers)* 
-                        _ =>  ctx.skip_value(seq)?
+                            _ =>  ctx.skip_value(seq)?
                         }
                     }
                 }

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -15,27 +15,15 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match input.data {
         Data::Struct(..) => {
             if struct_args.opaque {
-                generate_opaque(&input, struct_args)
-            } else {
-                let parsed_fields = parse_fields(&input);
-                // Check all parsed fields for any errors that may have occurred
-                let mut ok_fields: Vec<ParsedField> = vec![];
-                let mut errors = vec![];
-                for pf in parsed_fields {
-                    match pf {
-                        Ok(value) => ok_fields.push(value),
-                        Err(e) => errors.push(e),
-                    }
-                }
-
-                // If any error occurred, return them all here
-                if !errors.is_empty() {
-                    return proc_macro::TokenStream::from(darling::Error::multiple(errors).write_errors());
-                }
-
-                // Go ahead and generate the code
-                generate(&input, struct_args, ok_fields)
-            }
+                 generate_opaque(&input, struct_args)
+             } else {
+                 // Go ahead and generate the code                 
+                 match generate_enum(&input, struct_args) {
+                     //Ok(v) => {eprintln!("{}", v); v},
+                     Ok(v) => v,
+                     Err(v) => v,
+                 }
+             }
         }
         Data::Enum(..) => {
              if struct_args.opaque {
@@ -60,27 +48,12 @@ fn parse_field(f: &syn::Field) -> Result<ParsedField, darling::Error> {
     Ok(ParsedField { field_args })
 }
 
-fn parse_enum_fields(input: &syn::Fields) -> Vec<Result<ParsedField, darling::Error>> {
+fn parse_fields(input: &syn::Fields) -> Vec<Result<ParsedField, darling::Error>> {
     use syn::Fields;
     match input {
         Fields::Named(ref fields) => fields.named.iter().map(|f| parse_field(&f)).collect(),
         Fields::Unnamed(ref fields) => fields.unnamed.iter().map(|f| parse_field(&f)).collect(),
         Fields::Unit => vec![],
-    }
-}
-/// Walks all fields, parsing and verifying them
-fn parse_fields(input: &syn::DeriveInput) -> Vec<Result<ParsedField, darling::Error>> {
-    use syn::Data;
-    use syn::Fields;
-
-    match input.data {
-        Data::Struct(ref data) => {
-            match data.fields {
-                Fields::Named(ref fields) => fields.named.iter().map(|f| parse_field(&f)).collect(),
-                _ => unimplemented!(), // Fields::Unnamed, Fields::Unit currently not supported
-            }
-        }
-        _ => unimplemented!(), // Data::Enum, Data::Union currently not supported
     }
 }
 
@@ -91,8 +64,6 @@ struct ParsedField {
 }
 
 fn generate_enum_fields_diff(
-    _input: &syn::DeriveInput,
-    _struct_args: &args::SerdeDiffStructArgs,
     parsed_fields: &[ParsedField],
     matching : bool,
 ) -> proc_macro2::TokenStream {
@@ -187,7 +158,7 @@ fn enum_fields(fields : &syn::Fields, mutable: bool) -> (proc_macro2::TokenStrea
 }
 
 fn ok_fields(fields : &syn::Fields) -> Result<Vec<ParsedField>, proc_macro::TokenStream> {
-    let parsed_fields = parse_enum_fields(fields);
+    let parsed_fields = parse_fields(fields);
     // Check all parsed fields for any errors that may have occurred
     let mut ok_fields: Vec<ParsedField> = vec![];
     let mut errors = vec![];
@@ -205,110 +176,151 @@ fn ok_fields(fields : &syn::Fields) -> Result<Vec<ParsedField>, proc_macro::Toke
     }
 }
 
+fn generate_arms(name: &syn::Ident, variant: Option<&syn::Ident>, fields: &syn::Fields, matching: bool)
+                 -> Result<(Vec<proc_macro2::TokenStream>, Vec<proc_macro2::TokenStream>),
+                           proc_macro2::TokenStream>
+{
+    let mut diff_match_arms = vec![];
+    let mut apply_match_arms = vec![];
+    let parsed_fields = ok_fields(&fields)?;
+    let diffs = generate_enum_fields_diff(
+        &parsed_fields,
+        matching,
+    );                    
+    let (left, right) =  enum_fields(&fields, false);
+    let variant_specifier = if let Some(id) = variant {
+        quote!{ :: #id}
+    } else {
+        quote!{}
+    };
+    
+    let variant_as_str = variant.map(|i| i.to_string());
+    let push_variant = variant.map(|_| quote!{ctx.push_variant(#variant_as_str);});
+    let pop_variant = variant.map(|_| quote!{ctx.pop_path_element()?;});
+    
+    let left = if matching {
+        quote! { #name #variant_specifier #left }
+    } else {
+        quote! {_}
+    };
+    if matching {
+        diff_match_arms.push(                  
+            quote!{
+                (#left, #name #variant_specifier #right) => {
+                    #push_variant
+                    #diffs
+                    #pop_variant
+                }
+            }
+        );
+    } else {
+        diff_match_arms.push(                  
+            quote!{
+                (#left, #name #variant_specifier #right) => {
+                    ctx.push_full_variant();
+                    ctx.save_value(other)?;
+                    ctx.pop_path_element()?;
+                }
+            }
+        );  
+    }
+    
+    if matching {
+        let (left, _right) =  enum_fields(fields, true);
+        let mut apply_fn_field_handlers = vec![];
+        for (field_idx, pf) in parsed_fields.iter().enumerate() {
+            // Skip fields marked as #[serde_diff(skip)]
+            if pf.field_args.skip() {
+                continue;
+            }
+
+            let ident = pf.field_args.ident().clone();
+            let ty = pf.field_args.ty();
+            let field_idx = field_idx as u16;
+
+            let lhs = format_ident!("l{}", field_idx);
+            if pf.field_args.opaque() {
+                apply_fn_field_handlers.push(quote!(
+                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
+                        __changed__ |= ctx.read_value(seq, #lhs)?,
+                ));
+                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
+                    apply_fn_field_handlers.push(quote!(
+                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str =>
+                            __changed__ |= ctx.read_value(seq, #lhs)?,
+                    ));
+                }
+            } else {
+                apply_fn_field_handlers.push(quote!(
+                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
+                        __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
+                ));
+                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
+                    apply_fn_field_handlers.push(quote!(
+                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str => 
+                            __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
+                    ));
+                }
+            }
+        }
+
+        if let Some(_) = variant {
+            apply_match_arms.push(quote!{
+                ( &mut #name #variant_specifier #left, Some(serde_diff::DiffPathElementValue::EnumVariant(variant))) if variant == #variant_as_str => {
+                    while let Some(element) = ctx.next_path_element(seq)? {
+                        match element {
+                            #(#apply_fn_field_handlers)* 
+                        _ =>  ctx.skip_value(seq)?
+                        }
+                    }
+                }
+            });
+        } else {
+            apply_match_arms.push(quote!{
+                ( &mut #name #variant_specifier #left)  => {
+                    while let Some(element) = ctx.next_path_element(seq)? {
+                        match element {
+                            #(#apply_fn_field_handlers)* 
+                            _ =>  ctx.skip_value(seq)?
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    Ok((diff_match_arms, apply_match_arms))
+}
+
 fn generate_enum(
     input: &syn::DeriveInput,
     struct_args: args::SerdeDiffStructArgs,
 ) -> Result<proc_macro::TokenStream, proc_macro::TokenStream> {
+
+    use syn::Data;
     let mut diff_match_arms = vec![];
     let mut apply_match_arms = vec![];
-    use syn::Data;
 
-    match &input.data {
+    let has_variants = match &input.data {
         Data::Enum(e) => {
             for matching in &[true, false] {
                 for v in &e.variants {
-                    let name = &struct_args.ident;
-                    let variant = &v.ident;                    
-                    let parsed_fields = ok_fields(&v.fields)?;
-                    let diffs = generate_enum_fields_diff(
-                        input,
-                        &struct_args,
-                        &parsed_fields,
-                        *matching,
-                    );                    
-                    let (left, right) =  enum_fields(&v.fields, false);
-                    let variant_as_str = variant.to_string();
-                    let left = if *matching {
-                        quote! { #name :: #variant #left }
-                    } else {
-                        quote! {_}
-                    };
-                    if *matching {
-                        diff_match_arms.push(                  
-                            quote!{
-                                (#left, #name :: #variant #right) => {
-                                    ctx.push_variant(#variant_as_str);
-                                    #diffs
-                                    ctx.pop_path_element()?;
-                                }
-                            }
-                        );
-                    } else {
-                        diff_match_arms.push(                  
-                            quote!{
-                                (#left, #name :: #variant #right) => {
-                                    ctx.push_full_variant();
-                                    ctx.save_value(other)?;
-                                    ctx.pop_path_element()?;
-                                }
-                            }
-                        );  
-                    }
-                    
-                    if *matching {
-                        let (left, _right) =  enum_fields(&v.fields, true);
-                        let mut apply_fn_field_handlers = vec![];
-                        for (field_idx, pf) in parsed_fields.iter().enumerate() {
-                            // Skip fields marked as #[serde_diff(skip)]
-                            if pf.field_args.skip() {
-                                continue;
-                            }
-
-                            let ident = pf.field_args.ident().clone();
-                            let ty = pf.field_args.ty();
-                            let field_idx = field_idx as u16;
-
-                            let lhs = format_ident!("l{}", field_idx);
-                            if pf.field_args.opaque() {
-                                apply_fn_field_handlers.push(quote!(
-                                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
-                                        __changed__ |= ctx.read_value(seq, #lhs)?,
-                                ));
-                                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
-                                    apply_fn_field_handlers.push(quote!(
-                                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str =>
-                                            __changed__ |= ctx.read_value(seq, #lhs)?,
-                                    ));
-                                }
-                            } else {
-                                apply_fn_field_handlers.push(quote!(
-                                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
-                                        __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
-                                ));
-                                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
-                                    apply_fn_field_handlers.push(quote!(
-                                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str => 
-                                            __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
-                                ));
-                                }
-                            }
-                        }
-                        apply_match_arms.push(quote!{
-                            ( &mut #name :: #variant #left, Some(serde_diff::DiffPathElementValue::EnumVariant(variant))) if variant == #variant_as_str => {
-                                while let Some(element) = ctx.next_path_element(seq)? {
-                                    match element {
-                                        #(#apply_fn_field_handlers)* 
-                                        _ =>  ctx.skip_value(seq)?
-                                    }
-                                }
-                            }
-                        });
-                    }
+                    let (diff, apply) = generate_arms(&struct_args.ident, Some(&v.ident), &v.fields, *matching)?;
+                    diff_match_arms.extend(diff);
+                    apply_match_arms.extend(apply);
                 }
-            }
+            }            
+            true
+        }
+        Data::Struct(s) => {
+            let matching = true;
+            let (diff, apply) = generate_arms(&struct_args.ident, None, &s.fields, matching)?;
+            diff_match_arms.extend(diff);
+            apply_match_arms.extend(apply);
+            false
         }
         _ => {unreachable!("Unhandled Type in Enum")},
-    }
+    };
 
     // Generate the SerdeDiff::diff function for the type
     let diff_fn = quote! {
@@ -321,27 +333,47 @@ fn generate_enum(
         }
     };
 
+    
     // Generate the SerdeDiff::apply function for the type
     //TODO: Consider using something like the phf crate to avoid a string compare across field names,
     // or consider having the user manually tag their data with a number similar to protobuf
-    let apply_fn = quote! {
-        fn apply<'de, A>(
-            &mut self,
-            seq: &mut A,
-            ctx: &mut serde_diff::ApplyContext,
-        ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
-        where
-            A: serde_diff::_serde::de::SeqAccess<'de>, {
-            let mut __changed__ = false;
-            match (self, ctx.next_path_element(seq)?) {
-                (this, Some(serde_diff::DiffPathElementValue::FullEnumVariant)) => {
-                    ctx.read_value(seq, this)?;
-                    __changed__ = true;
+    let apply_fn = if has_variants {
+        quote! {
+            fn apply<'de, A>(
+                &mut self,
+                seq: &mut A,
+                ctx: &mut serde_diff::ApplyContext,
+            ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
+            where
+                A: serde_diff::_serde::de::SeqAccess<'de>, {
+                let mut __changed__ = false;
+                match (self, ctx.next_path_element(seq)?) {
+                    (this, Some(serde_diff::DiffPathElementValue::FullEnumVariant)) => {
+                        ctx.read_value(seq, this)?;
+                        __changed__ = true;
+                    }
+                    #(#apply_match_arms)*
+                    _ => ctx.skip_value(seq)?,
                 }
-                #(#apply_match_arms)*
-                _ => ctx.skip_value(seq)?,
+                Ok(__changed__)
             }
-            Ok(__changed__)
+        }
+    } else {
+        quote! {
+            fn apply<'de, A>(
+                &mut self,
+                seq: &mut A,
+                ctx: &mut serde_diff::ApplyContext,
+            ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
+            where
+                A: serde_diff::_serde::de::SeqAccess<'de>, {
+                let mut __changed__ = false;
+                match (self) {                   
+                    #(#apply_match_arms)*
+                    _ => ctx.skip_value(seq)?,
+                }
+                Ok(__changed__)
+            }
         }
     };
 
@@ -356,125 +388,6 @@ fn generate_enum(
     return Ok(proc_macro::TokenStream::from(quote! {
         #diff_impl
     }));
-}
-
-/// Takes the parsed input and produces implementation of the macro
-fn generate(
-    _input: &syn::DeriveInput,
-    struct_args: args::SerdeDiffStructArgs,
-    parsed_fields: Vec<ParsedField>,
-) -> proc_macro::TokenStream {
-    //let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    // This will hold a bit of code per-field that call diff on that field
-    let mut diff_fn_field_handlers = vec![];
-    for (field_idx, pf) in parsed_fields.iter().enumerate() {
-        // Skip fields marked as #[serde_diff(skip)]
-        if pf.field_args.skip() {
-            continue;
-        }
-
-        let ident = pf.field_args.ident().clone();
-        let ident_as_str = quote!(#ident).to_string();
-        let ty = pf.field_args.ty();
-        let field_idx = field_idx as u16;
-
-        if pf.field_args.opaque() {
-            diff_fn_field_handlers.push(quote! {
-                {
-                    ctx.push_field(#ident_as_str);
-                    if self.#ident != other.#ident {
-                        ctx.save_value(&other.#ident)?;
-                        __changed__ |= true;
-                    }
-                    ctx.pop_path_element()?;
-                }
-            });
-        } else {
-            diff_fn_field_handlers.push(quote! {
-                {
-                    {
-                        match ctx.field_path_mode() {
-                            serde_diff::FieldPathMode::Name => ctx.push_field(#ident_as_str),
-                            serde_diff::FieldPathMode::Index => ctx.push_field_index(#field_idx),
-                        }
-                        __changed__ |= <#ty as serde_diff::SerdeDiff>::diff(&self.#ident, ctx, &other.#ident)?;
-                        ctx.pop_path_element()?;
-                    }
-                }
-            });
-        }
-    }
-
-    // Generate the SerdeDiff::diff function for the type
-    let diff_fn = quote! {
-        fn diff<'a, S: serde_diff::_serde::ser::SerializeSeq>(&self, ctx: &mut serde_diff::DiffContext<'a, S>, other: &Self) -> Result<bool, S::Error> {
-            let mut __changed__ = false;
-            #(#diff_fn_field_handlers)*
-            Ok(__changed__)
-        }
-    };
-
-    // This will hold a bit of code per-field that call apply on that field
-    let mut apply_fn_field_handlers = vec![];
-    for (field_idx, pf) in parsed_fields.iter().enumerate() {
-        // Skip fields marked as #[serde_diff(skip)]
-        if pf.field_args.skip() {
-            continue;
-        }
-
-        let ident = pf.field_args.ident().clone();
-        let ident_as_str = quote!(#ident).to_string();
-        let ty = pf.field_args.ty();
-        let field_idx = field_idx as u16;
-
-        if pf.field_args.opaque() {
-            apply_fn_field_handlers.push(quote!(
-                serde_diff::DiffPathElementValue::FieldIndex(#field_idx) => __changed__ |= ctx.read_value(seq, &mut self.#ident)?,
-                serde_diff::DiffPathElementValue::Field(field_path) if field_path.as_ref() == #ident_as_str => __changed__ |= ctx.read_value(seq, &mut self.#ident)?,
-            ));
-        } else {
-            apply_fn_field_handlers.push(quote!(
-                serde_diff::DiffPathElementValue::FieldIndex(#field_idx) => __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(&mut self.#ident, seq, ctx)?,
-                serde_diff::DiffPathElementValue::Field(field_path) if field_path.as_ref() == #ident_as_str => __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(&mut self.#ident, seq, ctx)?,
-            ));
-        }
-    }
-
-    // Generate the SerdeDiff::apply function for the type
-    //TODO: Consider using something like the phf crate to avoid a string compare across field names,
-    // or consider having the user manually tag their data with a number similar to protobuf
-    let apply_fn = quote! {
-        fn apply<'de, A>(
-            &mut self,
-            seq: &mut A,
-            ctx: &mut serde_diff::ApplyContext,
-        ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
-        where
-            A: serde_diff::_serde::de::SeqAccess<'de>, {
-            let mut __changed__ = false;
-            while let Some(element) = ctx.next_path_element(seq)? {
-                match element {
-                    #(#apply_fn_field_handlers)*
-                    _ => ctx.skip_value(seq)?,
-                }
-            }
-            Ok(__changed__)
-        }
-    };
-
-    // Generate the impl block with the diff and apply functions within it
-    let struct_name = &struct_args.ident;
-    let diff_impl = quote! {
-        impl serde_diff::SerdeDiff for #struct_name {
-            #diff_fn
-            #apply_fn
-        }
-    };
-
-    return proc_macro::TokenStream::from(quote! {
-        #diff_impl
-    });
 }
 
 fn generate_opaque(

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -2,37 +2,54 @@ extern crate proc_macro;
 
 mod args;
 
-use quote::quote;
+use quote::{quote, format_ident};
 
 /// Reads in all tokens for the struct having the
 pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     use darling::FromDeriveInput;
-
+    use syn::Data;
+    
     // Parse the struct
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let struct_args = args::SerdeDiffStructArgs::from_derive_input(&input).unwrap();
+    match input.data {
+        Data::Struct(..) => {
+            if struct_args.opaque {
+                generate_opaque(&input, struct_args)
+            } else {
+                let parsed_fields = parse_fields(&input);
+                // Check all parsed fields for any errors that may have occurred
+                let mut ok_fields: Vec<ParsedField> = vec![];
+                let mut errors = vec![];
+                for pf in parsed_fields {
+                    match pf {
+                        Ok(value) => ok_fields.push(value),
+                        Err(e) => errors.push(e),
+                    }
+                }
 
-    if struct_args.opaque {
-        generate_opaque(&input, struct_args)
-    } else {
-        let parsed_fields = parse_fields(&input);
-        // Check all parsed fields for any errors that may have occurred
-        let mut ok_fields: Vec<ParsedField> = vec![];
-        let mut errors = vec![];
-        for pf in parsed_fields {
-            match pf {
-                Ok(value) => ok_fields.push(value),
-                Err(e) => errors.push(e),
+                // If any error occurred, return them all here
+                if !errors.is_empty() {
+                    return proc_macro::TokenStream::from(darling::Error::multiple(errors).write_errors());
+                }
+
+                // Go ahead and generate the code
+                generate(&input, struct_args, ok_fields)
             }
         }
-
-        // If any error occurred, return them all here
-        if !errors.is_empty() {
-            return proc_macro::TokenStream::from(darling::Error::multiple(errors).write_errors());
+        Data::Enum(..) => {
+             if struct_args.opaque {
+                 generate_opaque(&input, struct_args)
+             } else {
+                 // Go ahead and generate the code                 
+                 match generate_enum(&input, struct_args) {
+                     //Ok(v) => {eprintln!("{}", v); v},
+                     Ok(v) => v,
+                     Err(v) => v,
+                 }
+             }
         }
-
-        // Go ahead and generate the code
-        generate(&input, struct_args, ok_fields)
+        _ => unimplemented!()
     }
 }
 
@@ -40,10 +57,17 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 fn parse_field(f: &syn::Field) -> Result<ParsedField, darling::Error> {
     use darling::FromField;
     let field_args = args::SerdeDiffFieldArgs::from_field(&f)?;
-
     Ok(ParsedField { field_args })
 }
 
+fn parse_enum_fields(input: &syn::Fields) -> Vec<Result<ParsedField, darling::Error>> {
+    use syn::Fields;
+    match input {
+        Fields::Named(ref fields) => fields.named.iter().map(|f| parse_field(&f)).collect(),
+        Fields::Unnamed(ref fields) => fields.unnamed.iter().map(|f| parse_field(&f)).collect(),
+        Fields::Unit => vec![],
+    }
+}
 /// Walks all fields, parsing and verifying them
 fn parse_fields(input: &syn::DeriveInput) -> Vec<Result<ParsedField, darling::Error>> {
     use syn::Data;
@@ -64,6 +88,274 @@ fn parse_fields(input: &syn::DeriveInput) -> Vec<Result<ParsedField, darling::Er
 #[derive(Debug)]
 struct ParsedField {
     field_args: args::SerdeDiffFieldArgs,
+}
+
+fn generate_enum_fields_diff(
+    _input: &syn::DeriveInput,
+    _struct_args: &args::SerdeDiffStructArgs,
+    parsed_fields: &[ParsedField],
+    matching : bool,
+) -> proc_macro2::TokenStream {
+    // This will hold a bit of code per-field that call diff on that field
+    let mut diff_fn_field_handlers = vec![];
+    for (field_idx, pf) in parsed_fields.iter().enumerate() {
+        // Skip fields marked as #[serde_diff(skip)]
+        if pf.field_args.skip() {
+            continue;
+        }
+
+        let ident = pf.field_args.ident().clone();
+        let ident_as_str = quote!(#ident).to_string();
+        let ty = pf.field_args.ty();
+        let field_idx = field_idx as u16;
+        let left = format_ident!("l{}", field_idx);
+        let right = format_ident!("r{}", field_idx);
+
+        let push = if let Some(_) = ident {
+            quote!{ctx.push_field(#ident_as_str);}
+        } else {
+            quote!{ctx.push_field_index(#field_idx);}
+        };
+
+        if pf.field_args.opaque() || !matching {
+            let cmp = if matching {
+                quote! { #left != #right }
+            } else {
+                quote! {true}
+            };
+            diff_fn_field_handlers.push(quote! {
+                {
+                    #push
+                    if #cmp {
+                        ctx.save_value(&#right)?;
+                        __changed__ |= true;
+                    }
+                    ctx.pop_path_element()?;
+                }
+            });
+        } else {
+            diff_fn_field_handlers.push(quote! {
+                {
+                    {
+                        #push
+                        __changed__ |= <#ty as serde_diff::SerdeDiff>::diff(&#left, ctx, &#right)?;
+                        ctx.pop_path_element()?;
+                    }
+                }
+            });
+        }
+    }
+    quote! {
+        #(#diff_fn_field_handlers)*
+    }
+}
+
+
+fn enum_fields(fields : &syn::Fields, mutable: bool) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    use syn::Fields;
+    let field_match = |f: &syn::Field, name, idx| {
+        let name = format_ident!("{}{}", name, idx);
+        let mut_tok = if mutable {
+            Some(quote!(ref mut))
+        } else {
+            None
+        };
+        if let Some(n) = &f.ident {
+            quote! { #n :  #mut_tok #name }
+        } else {
+            quote! {#mut_tok #name}
+        }
+    };
+    let fields_match = |fields: &syn::Fields, prefix| {
+        match fields {
+            Fields::Named(n) => {
+                n.named.iter().enumerate().map(|(i, f)| field_match(f, prefix, i)).collect()
+            },
+            Fields::Unnamed(n) => {
+                n.unnamed.iter().enumerate().map(|(i, f)| field_match(f, prefix, i)).collect()
+            },
+            Fields::Unit => vec![]
+        }
+    };
+    let (left, right) = (fields_match(fields, "l"), fields_match(fields, "r"));    
+    let (left, right) = match fields {
+        Fields::Named(_)  => (quote!{{#(#left),*}}, quote!{{#(#right),*}}),
+        Fields::Unnamed(_)  => (quote!{(#(#left),*)}, quote!{(#(#right),*)}),
+        Fields::Unit => (quote!{}, quote!{}),
+    };
+    (left, right)
+}
+
+fn ok_fields(fields : &syn::Fields) -> Result<Vec<ParsedField>, proc_macro::TokenStream> {
+    let parsed_fields = parse_enum_fields(fields);
+    // Check all parsed fields for any errors that may have occurred
+    let mut ok_fields: Vec<ParsedField> = vec![];
+    let mut errors = vec![];
+    for pf in parsed_fields {
+        match pf {
+            Ok(value) => ok_fields.push(value),
+            Err(e) => errors.push(e),
+        }
+    }
+    // If any error occurred, return them all here
+    if !errors.is_empty() {
+       Err(proc_macro::TokenStream::from(darling::Error::multiple(errors).write_errors()))
+    } else {
+        Ok(ok_fields)
+    }
+}
+
+fn generate_enum(
+    input: &syn::DeriveInput,
+    struct_args: args::SerdeDiffStructArgs,
+) -> Result<proc_macro::TokenStream, proc_macro::TokenStream> {
+    let mut diff_match_arms = vec![];
+    let mut apply_match_arms = vec![];
+    use syn::Data;
+
+    match &input.data {
+        Data::Enum(e) => {
+            for matching in &[true, false] {
+                for v in &e.variants {
+                    let name = &struct_args.ident;
+                    let variant = &v.ident;                    
+                    let parsed_fields = ok_fields(&v.fields)?;
+                    let diffs = generate_enum_fields_diff(
+                        input,
+                        &struct_args,
+                        &parsed_fields,
+                        *matching,
+                    );                    
+                    let (left, right) =  enum_fields(&v.fields, false);
+                    let variant_as_str = variant.to_string();
+                    let left = if *matching {
+                        quote! { #name :: #variant #left }
+                    } else {
+                        quote! {_}
+                    };
+                    if *matching {
+                        diff_match_arms.push(                  
+                            quote!{
+                                (#left, #name :: #variant #right) => {
+                                    ctx.push_variant(#variant_as_str);
+                                    #diffs
+                                    ctx.pop_path_element()?;
+                                }
+                            }
+                        );
+                    } else {
+                        diff_match_arms.push(                  
+                            quote!{
+                                (#left, #name :: #variant #right) => {
+                                    ctx.push_full_variant();
+                                    ctx.save_value(other)?;
+                                    ctx.pop_path_element()?;
+                                }
+                            }
+                        );  
+                    }
+                    
+                    if *matching {
+                        let (left, _right) =  enum_fields(&v.fields, true);
+                        let mut apply_fn_field_handlers = vec![];
+                        for (field_idx, pf) in parsed_fields.iter().enumerate() {
+                            // Skip fields marked as #[serde_diff(skip)]
+                            if pf.field_args.skip() {
+                                continue;
+                            }
+
+                            let ident = pf.field_args.ident().clone();
+                            let ty = pf.field_args.ty();
+                            let field_idx = field_idx as u16;
+
+                            let lhs = format_ident!("l{}", field_idx);
+                            if pf.field_args.opaque() {
+                                apply_fn_field_handlers.push(quote!(
+                                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
+                                        __changed__ |= ctx.read_value(seq, #lhs)?,
+                                ));
+                                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
+                                    apply_fn_field_handlers.push(quote!(
+                                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str =>
+                                            __changed__ |= ctx.read_value(seq, #lhs)?,
+                                    ));
+                                }
+                            } else {
+                                apply_fn_field_handlers.push(quote!(
+                                    serde_diff::DiffPathElementValue::FieldIndex(#field_idx) =>
+                                        __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
+                                ));
+                                if let Some(ident_as_str) = ident.map(|s| s.to_string()) {
+                                    apply_fn_field_handlers.push(quote!(
+                                        serde_diff::DiffPathElementValue::Field(field) if field == #ident_as_str => 
+                                            __changed__ |= <#ty as serde_diff::SerdeDiff>::apply(#lhs, seq, ctx)?,
+                                ));
+                                }
+                            }
+                        }
+                        apply_match_arms.push(quote!{
+                            ( &mut #name :: #variant #left, Some(serde_diff::DiffPathElementValue::EnumVariant(variant))) if variant == #variant_as_str => {
+                                while let Some(element) = ctx.next_path_element(seq)? {
+                                    match element {
+                                        #(#apply_fn_field_handlers)* 
+                                        _ =>  ctx.skip_value(seq)?
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+        }
+        _ => {unreachable!("Unhandled Type in Enum")},
+    }
+
+    // Generate the SerdeDiff::diff function for the type
+    let diff_fn = quote! {
+        fn diff<'a, S: serde_diff::_serde::ser::SerializeSeq>(&self, ctx: &mut serde_diff::DiffContext<'a, S>, other: &Self) -> Result<bool, S::Error> {
+            let mut __changed__ = false;
+            match (self, other) {
+                #(#diff_match_arms)*
+            }
+            Ok(__changed__)
+        }
+    };
+
+    // Generate the SerdeDiff::apply function for the type
+    //TODO: Consider using something like the phf crate to avoid a string compare across field names,
+    // or consider having the user manually tag their data with a number similar to protobuf
+    let apply_fn = quote! {
+        fn apply<'de, A>(
+            &mut self,
+            seq: &mut A,
+            ctx: &mut serde_diff::ApplyContext,
+        ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
+        where
+            A: serde_diff::_serde::de::SeqAccess<'de>, {
+            let mut __changed__ = false;
+            match (self, ctx.next_path_element(seq)?) {
+                (this, Some(serde_diff::DiffPathElementValue::FullEnumVariant)) => {
+                    ctx.read_value(seq, this)?;
+                    __changed__ = true;
+                }
+                #(#apply_match_arms)*
+                _ => ctx.skip_value(seq)?,
+            }
+            Ok(__changed__)
+        }
+    };
+
+    // Generate the impl block with the diff and apply functions within it
+    let struct_name = &struct_args.ident;
+    let diff_impl = quote! {
+        impl serde_diff::SerdeDiff for #struct_name {
+            #diff_fn
+            #apply_fn
+        }
+    };
+    return Ok(proc_macro::TokenStream::from(quote! {
+        #diff_impl
+    }));
 }
 
 /// Takes the parsed input and produces implementation of the macro

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -71,16 +71,18 @@ impl<'a, S: SerializeSeq> DiffContext<'a, S> {
         self.element_stack
             .as_mut()
             .unwrap()
-            .push(ElementStackEntry::PathElement(DiffPathElementValue::EnumVariant(
-                Cow::Borrowed(variant_name),
-            )));
+            .push(ElementStackEntry::PathElement(
+                DiffPathElementValue::EnumVariant(Cow::Borrowed(variant_name)),
+            ));
     }
 
     pub fn push_full_variant(&mut self) {
         self.element_stack
             .as_mut()
             .unwrap()
-            .push(ElementStackEntry::PathElement(DiffPathElementValue::FullEnumVariant));
+            .push(ElementStackEntry::PathElement(
+                DiffPathElementValue::FullEnumVariant,
+            ));
     }
 
     /// Called when we visit a field. If the structure is recursive (i.e. struct within struct,

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -67,6 +67,22 @@ impl<'a, S: SerializeSeq> DiffContext<'a, S> {
             )));
     }
 
+    pub fn push_variant(&mut self, variant_name: &'static str) {
+        self.element_stack
+            .as_mut()
+            .unwrap()
+            .push(ElementStackEntry::PathElement(DiffPathElementValue::EnumVariant(
+                Cow::Borrowed(variant_name),
+            )));
+    }
+
+    pub fn push_full_variant(&mut self) {
+        self.element_stack
+            .as_mut()
+            .unwrap()
+            .push(ElementStackEntry::PathElement(DiffPathElementValue::FullEnumVariant));
+    }
+
     /// Called when we visit a field. If the structure is recursive (i.e. struct within struct,
     /// elements within an array) this may be called more than once before a corresponding pop_path_element
     /// is called. See `pop_path_element`
@@ -582,6 +598,8 @@ pub enum DiffPathElementValue<'a> {
     #[serde(borrow)]
     Field(Cow<'a, str>),
     FieldIndex(u16),
+    EnumVariant(Cow<'a, str>),
+    FullEnumVariant,
     CollectionIndex(usize),
     AddToCollection,
 }


### PR DESCRIPTION
- Supports unnamed fields, named fields and unit types enumerated types.
- As a side effect, structs also now supports unnamed fields, named fields and unit types.
- Additionally added basic support for generics types.

Open questions:

- Should diffs across enum variants be applied? This seems like it would open a bag of worms regarding default or uninitialized values.
- There is a risk of name ambiguity (notably with generic type names, lifetimes).

Note:
I am not super familiar with the implementation of procedural macros and may have overlooked important details in the effort of getting a working prototype.

Fixes #5, fixes #6.