### PR TITLE
Support Target Structs

### DIFF
--- a/serde-diff-derive/Cargo.toml
+++ b/serde-diff-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["parsing"] }
 darling = "0.10"
 
 [dev-dependencies]

--- a/serde-diff-derive/src/lib.rs
+++ b/serde-diff-derive/src/lib.rs
@@ -34,6 +34,44 @@ mod serde_diff;
 ///     heap: std::collections::HashSet<i32>,
 /// }
 /// ```
+///
+/// Example of diffing a target struct `MySimpleStruct` that is being used for serialization instead
+/// of the struct `MyComplexStruct` itself. Useful for cases where derived data is present at
+/// runtime, but not wanted in the serialized form.
+/// ```rust
+/// use serde_diff::SerdeDiff;
+/// use serde::{Serialize, Deserialize};
+/// #[derive(SerdeDiff, Serialize, Deserialize, Clone)]
+/// #[serde(from = "MySimpleStruct", into = "MySimpleStruct")]
+/// #[serde_diff(target = "MySimpleStruct")]
+/// struct MyComplexStruct {
+///    val: u32,
+///    derived_val: String,
+/// }
+///
+/// #[derive(SerdeDiff, Serialize, Deserialize, Default)]
+/// #[serde(rename = "MyComplexStruct", default)]
+/// struct MySimpleStruct {
+///    val: u32,
+/// }
+///
+/// impl From<MySimpleStruct> for MyComplexStruct {
+///    fn from(my_simple_struct: MySimpleStruct) -> Self {
+///        MyComplexStruct {
+///            val: my_simple_struct.val,
+///            derived_val: my_simple_struct.val.to_string(),
+///        }
+///    }
+/// }
+///
+/// impl Into<MySimpleStruct> for MyComplexStruct {
+///     fn into(self) -> MySimpleStruct {
+///         MySimpleStruct {
+///             val: self.val,
+///         }
+///     }
+/// }
+/// ```
 #[proc_macro_derive(SerdeDiff, attributes(serde_diff))]
 pub fn serde_diff_macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     serde_diff::macro_derive(input)

--- a/serde-diff-derive/src/serde_diff/args.rs
+++ b/serde-diff-derive/src/serde_diff/args.rs
@@ -9,6 +9,9 @@ pub struct SerdeDiffStructArgs {
     /// Whether the struct is opaque or not
     #[darling(default)]
     pub opaque: bool,
+    /// If specified, the struct we will convert to before performing diff operations
+    #[darling(default)]
+    pub target: Option<String>,
 
     pub generics: syn::Generics,
 }

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -361,7 +361,10 @@ fn generate(
             ) -> Result<bool, <A as serde_diff::_serde::de::SeqAccess<'de>>::Error>
             where
                 A: serde_diff::_serde::de::SeqAccess<'de>, {
-                    std::convert::Into::<#ty>::into(std::clone::Clone::clone(self)).apply(seq, ctx)
+                    let mut converted = std::convert::Into::<#ty>::into(std::clone::Clone::clone(self));
+                    let result = converted.apply(seq, ctx);
+                    *self = std::convert::From::<#ty>::from(converted);
+                    result
             }
         }
     } else {

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -20,19 +20,8 @@ pub fn macro_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         None
     };
     match input.data {
-        Data::Struct(..) => {
+        Data::Struct(..) | Data::Enum(..) => {
             if struct_args.opaque {
-                 generate_opaque(&input, struct_args)
-             } else {
-                 // Go ahead and generate the code                 
-                 match generate(&input, struct_args, target_type) {
-                     Ok(v) => v,
-                     Err(v) => v,
-                 }
-             }
-        }
-        Data::Enum(..) => {
-             if struct_args.opaque {
                  generate_opaque(&input, struct_args)
              } else {
                  // Go ahead and generate the code                 


### PR DESCRIPTION
Make it so that you can diff structs using serde's remote target struct feature (into/from the same struct):

```rust
#[derive(SerdeDiff, Serialize, Deserialize, Clone, PartialEq, Debug)]
#[serde(from = "MySimpleStruct", into = "MySimpleStruct")]
#[serde_diff(target = "MySimpleStruct")]
struct MyComplexStruct {
    // This field will be serialized
    a: u32,
    // This field will not be serialized, because it is not needed for <some reason>
    b: u32,
}

#[derive(SerdeDiff, Serialize, Deserialize, Default, PartialEq, Debug)]
#[serde(rename = "MyComplexStruct", default)]
struct MySimpleStruct {
    a: u32,
}

impl From<MySimpleStruct> for MyComplexStruct {
    fn from(my_simple_struct: MySimpleStruct) -> Self {
        MyComplexStruct {
            a: my_simple_struct.a,
            b: 0, // this value wasn't serialized, so we'll just default it to zero
        }
    }
}

impl Into<MySimpleStruct> for MyComplexStruct {
    fn into(self) -> MySimpleStruct {
        MySimpleStruct { a: self.a }
    }
}
```
