### PR TITLE
Fixing reference to serde::__private::from_utf8_lossy

### DIFF
--- a/src/difference.rs
+++ b/src/difference.rs
@@ -397,7 +397,7 @@ impl<'de> de::Visitor<'de> for DiffCommandFieldVisitor {
             b"RemoveKey" => Ok(DiffCommandField::RemoveKey),
             b"Exit" => Ok(DiffCommandField::Exit),
             _ => {
-                let value = &serde::export::from_utf8_lossy(value);
+                let value = &String::from_utf8_lossy(value);
                 Err(de::Error::unknown_variant(value, VARIANTS))
             }
         }


### PR DESCRIPTION
Fixing bug discussed in #24.
In the Serde repo, the method originally referenced is simply wrapping `String::from_utf8_lossy`. All tests pass.