### PR TITLE
Fix SerdeDerive macro implementation bug

### DIFF
--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -332,6 +332,9 @@ fn generate(
                 match (self, other) {
                     #(#diff_match_arms)*
                 }
+                if (__changed__) {
+                    ctx.save_exit()?;
+                }
                 Ok(__changed__)
             }
         }

--- a/serde-diff-derive/src/serde_diff/mod.rs
+++ b/serde-diff-derive/src/serde_diff/mod.rs
@@ -332,7 +332,7 @@ fn generate(
                 match (self, other) {
                     #(#diff_match_arms)*
                 }
-                if (__changed__) {
+                if __changed__ {
                     ctx.save_exit()?;
                 }
                 Ok(__changed__)

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -148,6 +148,11 @@ impl<'a, S: SerializeSeq> DiffContext<'a, S> {
         self.save_command(&DiffCommandRef::Value(value), true, true)
     }
 
+    /// Write exit command
+    pub fn save_exit(&mut self) -> Result<(), S::Error> {
+        self.save_command::<()>(&DiffCommandRef::Exit, true, false)
+    }
+
     /// Stores an arbitrary DiffCommand to be handled by the type.
     /// Any custom sequence of DiffCommands must be followed by Exit.
     pub fn save_command<'b, T: Serialize>(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,9 @@
 use crate as serde_diff;
 use crate::{Apply, Diff, SerdeDiff};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
+use std::iter::FromIterator;
 
 #[derive(SerdeDiff, Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
 struct TestStruct {
@@ -58,6 +60,18 @@ fn test_option() {
     roundtrip(
         Some(TestStruct { a: 52, b: 32. }),
         Some(TestStruct { a: 42, b: 12. }),
+    );
+    roundtrip(
+        HashMap::from_iter([
+            (1, TestStruct { a: 1, b: 1. }),
+            (2, TestStruct { a: 2, b: 2. }),
+            (3, TestStruct { a: 3, b: 3. }),
+        ]),
+        HashMap::from_iter([
+            (1, TestStruct { a: 1, b: 1. }),
+            (3, TestStruct { a: 4, b: 4. }),
+            (4, TestStruct { a: 1, b: 1. }),
+        ]),
     );
 
     partial(


### PR DESCRIPTION
Resolves #39 

Bug was caused because the SerdeDerive macro implementation didn't signal the end of diff for structure.