### PR TITLE
Remove target_os for wasm

### DIFF
--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -290,7 +290,7 @@ opaque_serde_diff!(f64);
 opaque_serde_diff!(char);
 opaque_serde_diff!(String);
 opaque_serde_diff!(std::ffi::CString);
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 opaque_serde_diff!(std::ffi::OsString);
 opaque_serde_diff!(std::num::NonZeroU8);
 opaque_serde_diff!(std::num::NonZeroU16);


### PR DESCRIPTION
One line alteration that fixes these errors when using wasm:

- "the trait bound OsString: Serialize is not satisfied"
- "the trait bound for<'c> OsString: Deserialize<'c> is not satisfied"